### PR TITLE
Add security headers to vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,25 @@
       "source": "/(.*)",
       "destination": "/index.html"
     }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        }
+      ]
+    }
   ]
 }
 


### PR DESCRIPTION
## Summary
- add a `headers` block in `vercel.json` with security headers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx vercel --version` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686176d272ec8330bdccae540d18fcac