### PR TITLE
Implement XRPL DEX order persistence

### DIFF
--- a/api/config/supabaseClient.js
+++ b/api/config/supabaseClient.js
@@ -99,8 +99,40 @@ export const updateUserProfile = async (userId, updates) => {
     .eq('id', userId)
     .select()
     .single();
-  
+
   return validateSupabaseResponse(data, error, 'Update user profile');
+};
+
+// Order management helpers
+export const insertOrder = async (orderData) => {
+  const { data, error } = await supabase
+    .from('orders')
+    .insert(orderData)
+    .select()
+    .single();
+
+  return validateSupabaseResponse(data, error, 'Insert order');
+};
+
+export const updateOrder = async (orderId, updates) => {
+  const { data, error } = await supabase
+    .from('orders')
+    .update(updates)
+    .eq('id', orderId)
+    .select()
+    .single();
+
+  return validateSupabaseResponse(data, error, 'Update order');
+};
+
+export const insertTradeHistory = async (tradeData) => {
+  const { data, error } = await supabase
+    .from('transactions')
+    .insert(tradeData)
+    .select()
+    .single();
+
+  return validateSupabaseResponse(data, error, 'Insert trade history');
 };
 
 export default supabase;

--- a/api/trading/orders.js
+++ b/api/trading/orders.js
@@ -1,4 +1,5 @@
-import { getXRPLClient, initializeXRPL } from '../config/xrpl.js';
+import { getXRPLClient, initializeXRPL, walletFromSeed, xrpToDrops } from '../config/xrpl.js';
+import { insertOrder, updateOrder, insertTradeHistory, supabase } from '../config/supabaseClient.js';
 import jwt from 'jsonwebtoken';
 
 export default async function handler(req, res) {
@@ -48,7 +49,6 @@ export default async function handler(req, res) {
       try {
         const orders = await getUserOrders({
           userId: decoded.userId,
-          userAddress: decoded.address,
           filters: {
             status,
             type,
@@ -83,14 +83,9 @@ export default async function handler(req, res) {
 
       } catch (error) {
         console.error('Orders fetch error:', error);
-        
-        // Fallback con dati mock
-        const mockOrders = generateMockOrders(decoded.userId);
-        
-        return res.status(200).json({
-          success: true,
-          ...mockOrders,
-          note: 'Dati simulati - Trading non disponibile'
+        return res.status(500).json({
+          success: false,
+          error: 'Impossibile recuperare gli ordini'
         });
       }
     }
@@ -103,28 +98,33 @@ export default async function handler(req, res) {
         tokenSymbol,
         quantity,
         price,
-        orderType = 'limit', // 'market', 'limit', 'stop_loss', 'take_profit'
-        timeInForce = 'GTC', // 'GTC' (Good Till Cancelled), 'IOC' (Immediate or Cancel), 'FOK' (Fill or Kill)
+        traderSeed,
+        takerGets,
+        takerPays,
+        orderType = 'limit',
+        timeInForce = 'GTC',
         stopPrice = null,
         expiration = null
       } = req.body;
 
-      if (!type || !assetId || !tokenSymbol || !quantity || (!price && orderType !== 'market')) {
+      if (!type || !assetId || !tokenSymbol || !quantity || !traderSeed || !takerGets || !takerPays) {
         return res.status(400).json({
           success: false,
-          error: 'Parametri richiesti: type, assetId, tokenSymbol, quantity, price (per ordini limit)'
+          error: 'Parametri richiesti: type, assetId, tokenSymbol, quantity, traderSeed, takerGets, takerPays'
         });
       }
 
       try {
         const order = await createTradingOrder({
           userId: decoded.userId,
-          userAddress: decoded.address,
           type: type,
           assetId: assetId,
           tokenSymbol: tokenSymbol,
           quantity: parseFloat(quantity),
           price: price ? parseFloat(price) : null,
+          traderSeed: traderSeed,
+          takerGets: takerGets,
+          takerPays: takerPays,
           orderType: orderType,
           timeInForce: timeInForce,
           stopPrice: stopPrice ? parseFloat(stopPrice) : null,
@@ -194,19 +194,21 @@ export default async function handler(req, res) {
 
     // DELETE - Cancella ordine
     if (req.method === 'DELETE') {
-      const { orderId } = req.query;
+      const { orderId, offerSequence, traderSeed } = req.query;
 
-      if (!orderId) {
+      if (!orderId || !offerSequence || !traderSeed) {
         return res.status(400).json({
           success: false,
-          error: 'orderId richiesto'
+          error: 'orderId, offerSequence e traderSeed richiesti'
         });
       }
 
       try {
         const cancelledOrder = await cancelTradingOrder({
           orderId: orderId,
-          userId: decoded.userId
+          userId: decoded.userId,
+          offerSequence: parseInt(offerSequence),
+          traderSeed: traderSeed
         });
 
         return res.status(200).json({
@@ -240,337 +242,150 @@ export default async function handler(req, res) {
   }
 }
 
-// Funzioni helper
-async function getUserOrders({ userId, userAddress, filters, pagination, sorting }) {
-  // Simula recupero ordini utente da XRPL DEX
-  const allOrders = await getAllUserOrders(userId);
-  
-  // Applica filtri
-  let filteredOrders = allOrders;
-  
-  if (filters.status !== 'all') {
-    filteredOrders = filteredOrders.filter(order => order.status === filters.status);
+
+// Helper functions
+async function getUserOrders({ userId, filters, pagination, sorting }) {
+  const start = (pagination.page - 1) * pagination.limit;
+  const end = start + pagination.limit - 1;
+
+  let query = supabase
+    .from('orders')
+    .select('*', { count: 'exact' })
+    .eq('user_id', userId);
+
+  if (filters.status !== 'all') query.eq('status', filters.status);
+  if (filters.type !== 'all') query.eq('order_type', filters.type);
+  if (filters.asset !== 'all') query.eq('asset_id', filters.asset);
+
+  if (sorting.sortBy) {
+    query = query.order(sorting.sortBy, { ascending: sorting.sortOrder === 'asc' });
   }
-  
-  if (filters.type !== 'all') {
-    filteredOrders = filteredOrders.filter(order => order.type === filters.type);
-  }
-  
-  if (filters.asset !== 'all') {
-    filteredOrders = filteredOrders.filter(order => order.assetId === filters.asset);
-  }
-  
-  // Ordinamento
-  filteredOrders.sort((a, b) => {
-    let aValue = a[sorting.sortBy];
-    let bValue = b[sorting.sortBy];
-    
-    if (sorting.sortBy === 'created_at' || sorting.sortBy === 'updated_at') {
-      aValue = new Date(aValue);
-      bValue = new Date(bValue);
-    }
-    
-    if (sorting.sortOrder === 'desc') {
-      return bValue > aValue ? 1 : -1;
-    } else {
-      return aValue > bValue ? 1 : -1;
-    }
-  });
-  
-  // Paginazione
-  const startIndex = (pagination.page - 1) * pagination.limit;
-  const endIndex = startIndex + pagination.limit;
-  const paginatedOrders = filteredOrders.slice(startIndex, endIndex);
-  
-  // Summary
-  const summary = calculateOrdersSummary(allOrders);
-  
-  return {
-    orders: paginatedOrders,
-    total: filteredOrders.length,
-    summary: summary
+
+  query = query.range(start, end);
+
+  const { data, error, count } = await query;
+  if (error) throw error;
+
+  const summary = calculateOrdersSummary(data);
+
+  return { orders: data, total: count || data.length, summary };
+}
+
+async function createTradingOrder({ userId, type, assetId, tokenSymbol, quantity, price, traderSeed, takerGets, takerPays, expiration }) {
+  await initializeXRPL();
+  const client = getXRPLClient();
+  const wallet = walletFromSeed(traderSeed);
+
+  const offer = {
+    TransactionType: 'OfferCreate',
+    Account: wallet.address,
+    TakerGets: takerGets,
+    TakerPays: takerPays
   };
-}
 
-async function getAllUserOrders(userId) {
-  // Simula ordini utente completi
-  return [
-    {
-      id: 'order_001',
-      userId: userId,
-      type: 'buy',
-      assetId: 'PROP001',
-      tokenSymbol: 'MHTN.OFFICE',
-      assetName: 'Manhattan Office Building',
-      quantity: 10,
-      price: 2600.00,
-      totalValue: 26000.00,
-      filled: 0,
-      remaining: 10,
-      orderType: 'limit',
-      timeInForce: 'GTC',
-      status: 'open',
-      created_at: '2024-02-20T10:30:00Z',
-      updated_at: '2024-02-20T10:30:00Z',
-      fees: {
-        trading: 26.00,
-        network: 0.001,
-        total: 26.001
-      },
-      estimatedExecution: '2024-02-20T11:00:00Z'
-    },
-    {
-      id: 'order_002',
-      userId: userId,
-      type: 'sell',
-      assetId: 'GOLD001',
-      tokenSymbol: 'GOLD.RESERVE',
-      assetName: 'Physical Gold Reserve',
-      quantity: 50,
-      price: 95.00,
-      totalValue: 4750.00,
-      filled: 50,
-      remaining: 0,
-      orderType: 'limit',
-      timeInForce: 'GTC',
-      status: 'filled',
-      created_at: '2024-02-19T14:15:00Z',
-      updated_at: '2024-02-19T14:45:00Z',
-      filled_at: '2024-02-19T14:45:00Z',
-      fees: {
-        trading: 4.75,
-        network: 0.001,
-        total: 4.751
-      },
-      execution: {
-        avgPrice: 95.00,
-        fills: [
-          {
-            quantity: 25,
-            price: 94.95,
-            timestamp: '2024-02-19T14:42:00Z'
-          },
-          {
-            quantity: 25,
-            price: 95.05,
-            timestamp: '2024-02-19T14:45:00Z'
-          }
-        ]
-      }
-    },
-    {
-      id: 'order_003',
-      userId: userId,
-      type: 'buy',
-      assetId: 'SOLAR001',
-      tokenSymbol: 'TX.SOLAR',
-      assetName: 'Texas Solar Farm',
-      quantity: 20,
-      price: 750.00,
-      totalValue: 15000.00,
-      filled: 12,
-      remaining: 8,
-      orderType: 'limit',
-      timeInForce: 'GTC',
-      status: 'partially_filled',
-      created_at: '2024-02-18T09:20:00Z',
-      updated_at: '2024-02-19T16:30:00Z',
-      fees: {
-        trading: 15.00,
-        network: 0.001,
-        total: 15.001
-      },
-      execution: {
-        avgPrice: 748.50,
-        fills: [
-          {
-            quantity: 12,
-            price: 748.50,
-            timestamp: '2024-02-19T16:30:00Z'
-          }
-        ]
-      }
-    }
-  ];
-}
+  if (expiration) offer.Expiration = expiration;
 
-async function createTradingOrder({
-  userId,
-  userAddress,
-  type,
-  assetId,
-  tokenSymbol,
-  quantity,
-  price,
-  orderType,
-  timeInForce,
-  stopPrice,
-  expiration
-}) {
-  // Simula creazione ordine su XRPL DEX
-  const orderId = 'order_' + Date.now();
-  
-  // Calcola fees
-  const totalValue = price ? quantity * price : 0;
-  const tradingFee = totalValue * 0.001; // 0.1%
-  const networkFee = 0.001; // XRP network fee
-  
-  const order = {
-    id: orderId,
-    userId: userId,
-    userAddress: userAddress,
-    type: type,
-    assetId: assetId,
-    tokenSymbol: tokenSymbol,
-    quantity: quantity,
-    price: price,
-    totalValue: totalValue,
-    filled: 0,
-    remaining: quantity,
-    orderType: orderType,
-    timeInForce: timeInForce,
-    stopPrice: stopPrice,
-    expiration: expiration,
-    status: 'open',
+  const prepared = await client.autofill(offer);
+  const signed = wallet.sign(prepared);
+  const result = await client.submitAndWait(signed.tx_blob);
+
+  const orderData = {
+    user_id: userId,
+    asset_id: assetId,
+    order_type: type,
+    tokens: quantity,
+    price_per_token: price,
+    total_amount: quantity * price,
+    status: 'pending',
     created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString(),
-    fees: {
-      trading: tradingFee,
-      network: networkFee,
-      total: tradingFee + networkFee
-    },
-    estimatedExecution: new Date(Date.now() + 30 * 60 * 1000).toISOString(), // 30 minuti
-    xrplTxHash: null // Sarà popolato quando l'ordine viene eseguito
+    expires_at: expiration ? new Date(expiration).toISOString() : null
   };
-  
-  // Simula validazione bilancio
-  if (type === 'buy') {
-    const requiredBalance = totalValue + order.fees.total;
-    // Qui si verificherebbe il bilancio XRP dell'utente
-  } else {
-    // Qui si verificherebbe il bilancio del token da vendere
-  }
-  
-  return order;
+
+  const savedOrder = await insertOrder(orderData);
+
+  await insertTradeHistory({
+    user_id: userId,
+    asset_id: assetId,
+    transaction_type: type,
+    tokens: quantity,
+    price_per_token: price,
+    total_amount: quantity * price,
+    status: 'pending',
+    transaction_hash: result.result.hash,
+    created_at: new Date().toISOString()
+  });
+
+  return { ...savedOrder, transaction: result.result };
 }
 
 async function updateTradingOrder({ orderId, userId, updates }) {
-  // Simula aggiornamento ordine
   const order = await getOrderById(orderId, userId);
-  
-  if (!order) {
-    throw new Error('Ordine non trovato');
-  }
-  
-  if (order.status !== 'open' && order.status !== 'partially_filled') {
-    throw new Error('Impossibile modificare ordine non aperto');
-  }
-  
-  // Applica aggiornamenti
-  const updatedOrder = {
-    ...order,
-    ...updates,
-    updated_at: new Date().toISOString()
-  };
-  
-  // Ricalcola fees se necessario
-  if (updates.quantity || updates.price) {
-    const totalValue = updatedOrder.price * updatedOrder.quantity;
-    updatedOrder.totalValue = totalValue;
-    updatedOrder.fees.trading = totalValue * 0.001;
-    updatedOrder.fees.total = updatedOrder.fees.trading + updatedOrder.fees.network;
-  }
-  
-  return updatedOrder;
+  if (!order) throw new Error('Ordine non trovato');
+
+  const saved = await updateOrder(orderId, updates);
+  return saved;
 }
 
-async function cancelTradingOrder({ orderId, userId }) {
-  // Simula cancellazione ordine
-  const order = await getOrderById(orderId, userId);
-  
-  if (!order) {
-    throw new Error('Ordine non trovato');
-  }
-  
-  if (order.status !== 'open' && order.status !== 'partially_filled') {
-    throw new Error('Impossibile cancellare ordine non aperto');
-  }
-  
-  const cancelledOrder = {
-    ...order,
-    status: 'cancelled',
-    cancelled_at: new Date().toISOString(),
-    updated_at: new Date().toISOString()
+async function cancelTradingOrder({ orderId, userId, offerSequence, traderSeed }) {
+  await initializeXRPL();
+  const client = getXRPLClient();
+  const wallet = walletFromSeed(traderSeed);
+
+  const cancelTx = {
+    TransactionType: 'OfferCancel',
+    Account: wallet.address,
+    OfferSequence: offerSequence
   };
-  
-  return cancelledOrder;
+
+  const prepared = await client.autofill(cancelTx);
+  const signed = wallet.sign(prepared);
+  const result = await client.submitAndWait(signed.tx_blob);
+
+  const cancelled = await updateOrder(orderId, { status: 'cancelled' });
+
+  await insertTradeHistory({
+    user_id: userId,
+    asset_id: cancelled.asset_id,
+    transaction_type: 'cancel',
+    tokens: cancelled.tokens,
+    price_per_token: cancelled.price_per_token,
+    total_amount: cancelled.total_amount,
+    status: 'cancelled',
+    transaction_hash: result.result.hash,
+    created_at: new Date().toISOString()
+  });
+
+  return cancelled;
 }
 
 async function getOrderById(orderId, userId) {
-  // Simula recupero ordine per ID
-  const allOrders = await getAllUserOrders(userId);
-  return allOrders.find(order => order.id === orderId);
+  const { data, error } = await supabase
+    .from('orders')
+    .select('*')
+    .eq('id', orderId)
+    .eq('user_id', userId)
+    .single();
+  if (error) return null;
+  return data;
 }
 
 function calculateOrdersSummary(orders) {
   const summary = {
     total: orders.length,
-    open: 0,
-    filled: 0,
-    cancelled: 0,
-    partially_filled: 0,
-    totalVolume: 0,
-    totalFees: 0,
+    open: orders.filter(o => o.status === 'pending' || o.status === 'open').length,
+    filled: orders.filter(o => o.status === 'completed').length,
+    cancelled: orders.filter(o => o.status === 'cancelled').length,
+    partially_filled: orders.filter(o => o.status === 'partial').length,
+    totalVolume: orders.reduce((a, o) => a + parseFloat(o.total_amount || 0), 0),
     avgOrderSize: 0,
-    successRate: 0
+    successRate: 0,
+    totalFees: 0
   };
-  
-  orders.forEach(order => {
-    summary[order.status]++;
-    summary.totalVolume += order.totalValue;
-    summary.totalFees += order.fees.total;
-  });
-  
-  summary.avgOrderSize = summary.totalVolume / orders.length || 0;
-  summary.successRate = ((summary.filled + summary.partially_filled) / orders.length * 100) || 0;
-  
+
+  summary.avgOrderSize = summary.totalVolume / (summary.total || 1);
+  if (summary.total > 0) {
+    summary.successRate = ((summary.filled + summary.partially_filled) / summary.total) * 100;
+  }
+
   return summary;
 }
-
-function generateMockOrders(userId) {
-  const mockOrders = [
-    {
-      id: 'order_001',
-      type: 'buy',
-      assetId: 'PROP001',
-      tokenSymbol: 'MHTN.OFFICE',
-      quantity: 10,
-      price: 2600.00,
-      status: 'open',
-      created_at: '2024-02-20T10:30:00Z'
-    },
-    {
-      id: 'order_002',
-      type: 'sell',
-      assetId: 'GOLD001',
-      tokenSymbol: 'GOLD.RESERVE',
-      quantity: 50,
-      price: 95.00,
-      status: 'filled',
-      created_at: '2024-02-19T14:15:00Z'
-    }
-  ];
-  
-  return {
-    orders: mockOrders,
-    total: mockOrders.length,
-    pagination: { page: 1, limit: 20, pages: 1 },
-    summary: {
-      total: 2,
-      open: 1,
-      filled: 1,
-      totalVolume: 30750.00
-    }
-  };
-}
-


### PR DESCRIPTION
## Summary
- support order creation on XRPL via `OfferCreate`
- persist orders & trade history using Supabase
- add DB helpers for orders and trades
- remove mock trading helpers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686176d19d4c8330aaa0905d2cb94df2