### PR TITLE
Update README admin guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,7 @@ npm run dev
 
 ## 🔐 Default Credentials
 
-**Admin User:**
-- Email: `admin@solcraft-nexus.com`
-- Password: `admin123`
+Admins should create their own administrator credentials through the SolCraft Nexus platform.
 
 ## 🌟 Core Functionalities
 


### PR DESCRIPTION
## Summary
- remove default admin credentials from README
- instruct admins to create credentials via the platform

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686176c711f8833091436ebd51ce71e4