### PR TITLE
Improve security documentation and CORS defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,13 @@ npm run dev
 - `POST /api/v1/security/mfa/verify` - Verify 2FA
 - `GET /api/v1/security/report` - Security report
 
-## 🔐 Default Credentials
+## 🔐 Demo Credentials
 
-**Admin User:**
+**Demo Admin User (for testing only):**
 - Email: `admin@solcraft-nexus.com`
 - Password: `admin123`
+
+> **Note**: These credentials are intended solely for demonstration and testing purposes. Replace them in production environments.
 
 ## 🌟 Core Functionalities
 

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -45,7 +45,8 @@ class Config:
     BCRYPT_LOG_ROUNDS = 12
     
     # CORS Configuration
-    CORS_ORIGINS = os.environ.get('CORS_ORIGINS', '*').split(',')
+    # Use comma-separated list from the environment; fallback to the local frontend URL
+    CORS_ORIGINS = os.environ.get('CORS_ORIGINS', 'http://localhost:3000').split(',')
     
     # File Upload Configuration
     MAX_CONTENT_LENGTH = 16 * 1024 * 1024  # 16MB max file size


### PR DESCRIPTION
## Summary
- mark admin credentials in README as demo-only
- restrict backend default CORS origins to localhost

## Testing
- `npm run lint` *(fails: no-unused-vars, no-undef)*

------
https://chatgpt.com/codex/tasks/task_e_68617444fb748330a9c3615c323c45d0