### PR TITLE
Add security headers to Vercel configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,16 @@
       "source": "/(.*)",
       "destination": "/index.html"
     }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "X-XSS-Protection", "value": "1; mode=block" }
+      ]
+    }
   ]
 }
 


### PR DESCRIPTION
## Summary
- configure security headers in `vercel.json`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm run build` *(fails: vite not found, probably due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861743e22b0833096dc7557c19f2b6c