### PR TITLE
Add real XRPL operations

### DIFF
--- a/api/tokenization/create.js
+++ b/api/tokenization/create.js
@@ -97,21 +97,47 @@ export default async function handler(req, res) {
       // Inizializza connessione XRPL
       await initializeXRPL().catch(() => {}); // Ignora se già connesso
 
-      // TODO: Implementare creazione token reale su XRPL
-      // Per ora simuliamo il processo con dati realistici
-      
-      // Simula indirizzo issuer (in produzione sarebbe il tuo issuing address)
-      const mockIssuerAddress = 'rN7n7otQDd6FczFgLdSqtcsAUxDkw6fzRH';
-      const mockTxHash = `${tokenSymbol}${Date.now().toString(16).toUpperCase()}`;
+      const issuerSeed = process.env.XRPL_ISSUER_SEED;
+      if (!issuerSeed) {
+        throw new Error('XRPL_ISSUER_SEED not configured');
+      }
+      const hotSeed = process.env.XRPL_HOT_WALLET_SEED || issuerSeed;
 
-      tokenCreationResult = {
-        success: true,
-        txHash: mockTxHash,
-        issuerAddress: mockIssuerAddress,
-        tokenSymbol: tokenSymbol,
-        totalSupply: supply.toString(),
-        created: true
+      const issuerWallet = walletFromSeed(issuerSeed);
+      const hotWallet = walletFromSeed(hotSeed);
+
+      // Crea trust line per consentire al wallet operativo di detenere il token
+      await createTrustLine(hotWallet, tokenSymbol, issuerWallet.address, supply.toString());
+
+      // Creazione transazione di emissione token
+      const client = getXRPLClient();
+      const paymentTx = {
+        TransactionType: 'Payment',
+        Account: issuerWallet.address,
+        Destination: hotWallet.address,
+        Amount: {
+          currency: tokenSymbol,
+          issuer: issuerWallet.address,
+          value: supply.toString()
+        }
       };
+
+      const prepared = await client.autofill(paymentTx);
+      const signed = issuerWallet.sign(prepared);
+      const result = await client.submitAndWait(signed.tx_blob);
+
+      if (result.result.meta.TransactionResult === 'tesSUCCESS') {
+        tokenCreationResult = {
+          success: true,
+          txHash: result.result.hash,
+          issuerAddress: issuerWallet.address,
+          tokenSymbol: tokenSymbol,
+          totalSupply: supply.toString(),
+          created: true
+        };
+      } else {
+        throw new Error(result.result.meta.TransactionResult);
+      }
 
     } catch (error) {
       console.error('Token creation error:', error);


### PR DESCRIPTION
## Summary
- issue assets on XRPL in tokenization API using real transactions
- create MPT tokens via `MPTokenIssuanceCreate`
- send XRP and issued tokens from Python backend using xrpl service

## Testing
- `npm run lint` *(fails: __dirname not defined and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861742e2b448330a8572c217bb58a67