### PR TITLE
Implement real XRPL transactions

### DIFF
--- a/backend/src/routes/wallet.py
+++ b/backend/src/routes/wallet.py
@@ -174,27 +174,30 @@ def send_crypto():
         if not xrpl_service.validate_address(destination):
             return jsonify({'error': 'Invalid destination address'}), 400
         
-        # For demo purposes, we'll simulate the transaction
-        # In production, you'd retrieve the user's wallet securely and send the transaction
-        
+        # Recupera il wallet custodial dell'utente per firmare la transazione
+        sender_wallet = secure_wallet_service.get_wallet_for_transaction(current_user_id)
+
         if currency == 'XRP':
-            # Simulate XRP transaction
-            transaction_result = {
-                'success': True,
-                'hash': f'demo_hash_{current_user_id}_{datetime.utcnow().timestamp()}',
-                'amount_sent': amount,
-                'destination': destination,
-                'fee': Decimal('0.00001')
-            }
+            transaction_result = xrpl_service.send_xrp(
+                sender_wallet,
+                destination=destination,
+                amount=amount,
+                destination_tag=int(destination_tag) if destination_tag else None,
+                memo=memo
+            )
         else:
-            # Simulate token transaction
-            transaction_result = {
-                'success': True,
-                'hash': f'demo_hash_{current_user_id}_{datetime.utcnow().timestamp()}',
-                'currency': currency,
-                'amount_sent': amount,
-                'destination': destination
-            }
+            issuer = data.get('issuer')
+            if not issuer:
+                return jsonify({'error': 'issuer is required for token transfers'}), 400
+
+            transaction_result = xrpl_service.send_token(
+                sender_wallet,
+                destination=destination,
+                currency=currency,
+                issuer=issuer,
+                amount=amount,
+                destination_tag=int(destination_tag) if destination_tag else None
+            )
         
         # Record transaction in database
         transaction = Transaction(


### PR DESCRIPTION
## Summary
- enable real tokenization via XRPL in api route
- issue MPT using XRPL when available
- send real XRP or token payments from Python backend

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68616a1635ac8330920daa99c1c126a3