### PR TITLE
Add security_events table update

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ pip install -r requirements.txt
 python src/main.py
 ```
 
+### Database Update
+If you already have a database from a previous version, run the migration script
+to rename the `metadata` column in `security_events`:
+
+```bash
+python database/rename_security_events_metadata.py
+```
+
 ### Frontend Setup
 ```bash
 cd frontend

--- a/database/rename_security_events_metadata.py
+++ b/database/rename_security_events_metadata.py
@@ -1,0 +1,25 @@
+import os
+from sqlalchemy import create_engine, inspect, text
+from backend.src.config import Config
+
+DB_URI = os.environ.get('DATABASE_URL') or Config.SQLALCHEMY_DATABASE_URI
+
+def main():
+    engine = create_engine(DB_URI)
+    with engine.connect() as conn:
+        inspector = inspect(conn)
+        if 'security_events' not in inspector.get_table_names():
+            print("Table 'security_events' does not exist. Nothing to do.")
+            return
+        columns = [col['name'] for col in inspector.get_columns('security_events')]
+        if 'event_metadata' in columns:
+            print("Column 'event_metadata' already exists. No action needed.")
+            return
+        if 'metadata' in columns:
+            conn.execute(text('ALTER TABLE security_events RENAME COLUMN metadata TO event_metadata'))
+            print("Renamed column 'metadata' to 'event_metadata'.")
+            return
+        print("Column 'metadata' not found. No changes made.")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a simple migration script to rename `metadata` to `event_metadata`
- document the database update in README

## Testing
- `python -m py_compile database/rename_security_events_metadata.py`

------
https://chatgpt.com/codex/tasks/task_e_68613885833883309a33c1c28d1c6040