### PR TITLE
Switch user/asset FK columns to UUID

### DIFF
--- a/backend/src/services/governance_service.py
+++ b/backend/src/services/governance_service.py
@@ -23,8 +23,8 @@ class Proposal(db.Model):
     __tablename__ = 'proposals'
     
     id = db.Column(db.Integer, primary_key=True)
-    asset_id = db.Column(db.Integer, db.ForeignKey('assets.id'), nullable=False)
-    creator_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    asset_id = db.Column(db.String(36), db.ForeignKey('assets.id'), nullable=False)
+    creator_id = db.Column(db.String(36), db.ForeignKey('users.id'), nullable=False)
     
     title = db.Column(db.String(200), nullable=False)
     description = db.Column(db.Text, nullable=False)
@@ -80,7 +80,7 @@ class Vote(db.Model):
     
     id = db.Column(db.Integer, primary_key=True)
     proposal_id = db.Column(db.Integer, db.ForeignKey('proposals.id'), nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    user_id = db.Column(db.String(36), db.ForeignKey('users.id'), nullable=False)
     
     choice = db.Column(db.Enum(VoteChoice), nullable=False)
     voting_power = db.Column(db.Decimal(20, 8), nullable=False)  # Based on token holdings

--- a/backend/src/services/mfa_service.py
+++ b/backend/src/services/mfa_service.py
@@ -12,7 +12,7 @@ class TwoFactorAuth(db.Model):
     __tablename__ = 'two_factor_auth'
     
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False, unique=True)
+    user_id = db.Column(db.String(36), db.ForeignKey('users.id'), nullable=False, unique=True)
     
     # TOTP settings
     secret_key = db.Column(db.String(32), nullable=False)
@@ -43,7 +43,7 @@ class LoginAttempt(db.Model):
     __tablename__ = 'login_attempts'
     
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('users.id'))
+    user_id = db.Column(db.String(36), db.ForeignKey('users.id'))
     ip_address = db.Column(db.String(45), nullable=False)
     user_agent = db.Column(db.String(500))
     
@@ -73,7 +73,7 @@ class SecurityEvent(db.Model):
     __tablename__ = 'security_events'
     
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('users.id'))
+    user_id = db.Column(db.String(36), db.ForeignKey('users.id'))
     
     event_type = db.Column(db.String(50), nullable=False)  # login, password_change, 2fa_enabled, etc.
     severity = db.Column(db.String(20), default='info')  # info, warning, critical

--- a/backend/src/services/multi_user_service.py
+++ b/backend/src/services/multi_user_service.py
@@ -73,14 +73,14 @@ class OrganizationMembership(db.Model):
     
     id = db.Column(db.Integer, primary_key=True)
     organization_id = db.Column(db.Integer, db.ForeignKey('organizations.id'), nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    user_id = db.Column(db.String(36), db.ForeignKey('users.id'), nullable=False)
     
     role = db.Column(db.Enum(RoleType), nullable=False)
     status = db.Column(db.String(20), default='active')  # active, suspended, pending
     
     # Metadata
     joined_at = db.Column(db.DateTime, default=datetime.utcnow)
-    invited_by = db.Column(db.Integer, db.ForeignKey('users.id'))
+    invited_by = db.Column(db.String(36), db.ForeignKey('users.id'))
     
     # Constraints
     __table_args__ = (
@@ -102,12 +102,12 @@ class UserPermission(db.Model):
     __tablename__ = 'user_permissions'
     
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    user_id = db.Column(db.String(36), db.ForeignKey('users.id'), nullable=False)
     organization_id = db.Column(db.Integer, db.ForeignKey('organizations.id'))
-    asset_id = db.Column(db.Integer, db.ForeignKey('assets.id'))
+    asset_id = db.Column(db.String(36), db.ForeignKey('assets.id'))
     
     permission = db.Column(db.Enum(PermissionType), nullable=False)
-    granted_by = db.Column(db.Integer, db.ForeignKey('users.id'))
+    granted_by = db.Column(db.String(36), db.ForeignKey('users.id'))
     granted_at = db.Column(db.DateTime, default=datetime.utcnow)
     expires_at = db.Column(db.DateTime)  # Optional expiration
     
@@ -127,9 +127,9 @@ class AuditLog(db.Model):
     __tablename__ = 'audit_logs'
     
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.Integer, db.ForeignKey('users.id'))
+    user_id = db.Column(db.String(36), db.ForeignKey('users.id'))
     organization_id = db.Column(db.Integer, db.ForeignKey('organizations.id'))
-    asset_id = db.Column(db.Integer, db.ForeignKey('assets.id'))
+    asset_id = db.Column(db.String(36), db.ForeignKey('assets.id'))
     
     action = db.Column(db.String(100), nullable=False)
     resource_type = db.Column(db.String(50), nullable=False)


### PR DESCRIPTION
## Summary
- use `db.String(36)` for user and asset foreign keys in MFA, Governance and MultiUser services

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68613d6b6dc0833080eb561e2ef237f1