### PR TITLE
Fix wallet_service import in wallet routes

### DIFF
--- a/backend/src/routes/wallet.py
+++ b/backend/src/routes/wallet.py
@@ -2,7 +2,7 @@ from flask import Blueprint, request, jsonify
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from src.models.user import db, User
 from src.models.transaction import Transaction
-from src.services.wallet_service import xrpl_service
+from src.services.wallet_service import wallet_service, xrpl_service
 from src.services.secure_wallet_service import secure_wallet_service
 from src.services.transaction_optimization_service import transaction_optimization_service
 from src.services.blockchain_notification_service import blockchain_notification_service


### PR DESCRIPTION
## Summary
- ensure wallet routes import `wallet_service`

## Testing
- `python3 -m py_compile backend/src/routes/wallet.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861415dc360833090c54d740a6b5b19