### PR TITLE
Add schedule dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ solcraft-nexus/
 cd backend
 python -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
-pip install -r requirements.txt
+pip install -r requirements.txt  # installs packages like schedule
 python src/main.py
 ```
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -53,3 +53,4 @@ websockets==15.0.1
 Werkzeug==3.1.3
 wrapt==1.17.2
 xrpl-py==4.2.0
+schedule==1.2.1


### PR DESCRIPTION
## Summary
- append `schedule==1.2.1` to backend requirements
- mention new dependency in the backend setup instructions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861415e44088330a5d6e7cc3e880de0