### PR TITLE
Add Supabase token persistence

### DIFF
--- a/api/tokenization/details.js
+++ b/api/tokenization/details.js
@@ -1,0 +1,49 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.SUPABASE_URL
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY
+const supabase = createClient(supabaseUrl, supabaseKey)
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end()
+  }
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ success: false, error: 'Method not allowed' })
+  }
+
+  const { id } = req.query
+  if (!id) {
+    return res.status(400).json({ success: false, error: 'Token id required' })
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('tokens')
+      .select('*')
+      .eq('id', id)
+      .single()
+
+    if (error) {
+      return res.status(404).json({
+        success: false,
+        error: 'Token non trovato',
+        message: error.message,
+      })
+    }
+
+    return res.status(200).json({ success: true, token: data })
+  } catch (err) {
+    console.error('Token details error:', err)
+    return res.status(500).json({
+      success: false,
+      error: 'Errore interno del server',
+      message: err.message,
+    })
+  }
+}

--- a/api/tokenization/list.js
+++ b/api/tokenization/list.js
@@ -1,0 +1,43 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.SUPABASE_URL
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY
+const supabase = createClient(supabaseUrl, supabaseKey)
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end()
+  }
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ success: false, error: 'Method not allowed' })
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('tokens')
+      .select('*')
+      .order('created_at', { ascending: false })
+
+    if (error) {
+      return res.status(500).json({
+        success: false,
+        error: 'Errore nel recupero dei token',
+        message: error.message,
+      })
+    }
+
+    return res.status(200).json({ success: true, tokens: data })
+  } catch (err) {
+    console.error('Token list error:', err)
+    return res.status(500).json({
+      success: false,
+      error: 'Errore interno del server',
+      message: err.message,
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- initialize Supabase inside the tokenization API using env vars
- store created tokens in the `tokens` table
- expose `list` and `details` endpoints to retrieve tokens
- add DB error handling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686153a79df483308b18afa1a5fbab5b