### PR TITLE
Use env vars for Supabase service role

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,8 @@ REACT_APP_XRPL_TESTNET=wss://s.altnet.rippletest.net:51233
 # Supabase Configuration
 REACT_APP_SUPABASE_URL=your-supabase-url-here
 REACT_APP_SUPABASE_ANON_KEY=your-supabase-anon-key-here
+SUPABASE_URL=your-supabase-url-here
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key-here
 
 # API Configuration
 REACT_APP_API_BASE_URL=https://solcraft-nexus-tokenize-v1.vercel.app/api

--- a/api/mpt/advanced.js
+++ b/api/mpt/advanced.js
@@ -5,8 +5,8 @@ import { createClient } from '@supabase/supabase-js'
 import { Client, Wallet, xrpToDrops, dropsToXrp } from 'xrpl'
 
 // Configurazione
-const supabaseUrl = 'https://dtzlkcqddjaoubrjnzjw.supabase.co'
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImR0emxrY3FkZGphb3VicmpuempqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzUyMDQ5NjMsImV4cCI6MjA1MDc4MDk2M30.eYJhbGc1OjJIUzI1NiIsInR5cCI6IkpXVCJ9'
+const supabaseUrl = process.env.SUPABASE_URL
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
 const supabase = createClient(supabaseUrl, supabaseKey)
 

--- a/api/users/manage.js
+++ b/api/users/manage.js
@@ -7,8 +7,8 @@ import jwt from 'jsonwebtoken'
 import bcrypt from 'bcryptjs'
 
 // Configurazione
-const supabaseUrl = 'https://dtzlkcqddjaoubrjnzjw.supabase.co'
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImR0emxrY3FkZGphb3VicmpuempqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzUyMDQ5NjMsImV4cCI6MjA1MDc4MDk2M30.eYJhbGc1OjJIUzI1NiIsInR5cCI6IkpXVCJ9'
+const supabaseUrl = process.env.SUPABASE_URL
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
 const supabase = createClient(supabaseUrl, supabaseKey)
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,8 @@
 
 [build.environment]
   NODE_VERSION = "20"
+  SUPABASE_URL = "${SUPABASE_URL}"
+  SUPABASE_SERVICE_ROLE_KEY = "${SUPABASE_SERVICE_ROLE_KEY}"
 
 [[redirects]]
   from = "/api/*"

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,10 @@
   "version": 2,
   "buildCommand": "pnpm run build",
   "outputDirectory": "dist",
+  "env": {
+    "SUPABASE_URL": "@supabase_url",
+    "SUPABASE_SERVICE_ROLE_KEY": "@supabase_service_role_key"
+  },
   "rewrites": [
     {
       "source": "/api/(.*)",


### PR DESCRIPTION
## Summary
- inject service role env vars into API handlers
- document Supabase backend variables
- provide env vars in deployment configs

## Testing
- `pnpm lint` *(fails: 377 problems)*

------
https://chatgpt.com/codex/tasks/task_e_686153aa3288833097cdf69324887631