### PR TITLE
Add supabase token storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ REACT_APP_XRPL_TESTNET=wss://s.altnet.rippletest.net:51233
 REACT_APP_SUPABASE_URL=your-supabase-url-here
 REACT_APP_SUPABASE_ANON_KEY=your-supabase-anon-key-here
 
+# Server-side Supabase configuration
+SUPABASE_URL=your-supabase-url-here
+SUPABASE_ANON_KEY=your-supabase-anon-key-here
+
 # API Configuration
 REACT_APP_API_BASE_URL=https://solcraft-nexus-tokenize-v1.vercel.app/api
 

--- a/api/tokenization/list.js
+++ b/api/tokenization/list.js
@@ -1,0 +1,76 @@
+import { createClient } from '@supabase/supabase-js'
+import jwt from 'jsonwebtoken'
+
+const supabaseUrl = process.env.SUPABASE_URL
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY
+const supabase = createClient(supabaseUrl, supabaseAnonKey)
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end()
+  }
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({
+      success: false,
+      error: 'Method not allowed. Use GET to retrieve tokens.'
+    })
+  }
+
+  try {
+    const authHeader = req.headers.authorization
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return res.status(401).json({
+        success: false,
+        error: 'Token di autenticazione richiesto'
+      })
+    }
+
+    const token = authHeader.substring(7)
+    const jwtSecret = process.env.JWT_SECRET || 'fallback-secret-key-for-development'
+
+    let decoded
+    try {
+      decoded = jwt.verify(token, jwtSecret)
+    } catch {
+      return res.status(401).json({ success: false, error: 'Token non valido' })
+    }
+
+    const { tokenId, symbol, limit = 50, offset = 0 } = req.query
+
+    let query = supabase.from('tokens').select('*').eq('creator_id', decoded.userId)
+
+    if (tokenId) {
+      const { data, error } = await query.eq('id', tokenId).single()
+      if (error) {
+        console.error('Supabase fetch error:', error)
+        return res.status(500).json({ success: false, error: 'Errore nel recupero del token' })
+      }
+      return res.status(200).json({ success: true, token: data })
+    }
+
+    if (symbol) query = query.eq('token_symbol', symbol)
+
+    const start = parseInt(offset)
+    const end = start + parseInt(limit) - 1
+    const { data, error } = await query.range(start, end)
+
+    if (error) {
+      console.error('Supabase fetch error:', error)
+      return res.status(500).json({ success: false, error: 'Errore nel recupero dei token' })
+    }
+
+    return res.status(200).json({
+      success: true,
+      tokens: data,
+      pagination: { limit: parseInt(limit), offset: parseInt(offset) }
+    })
+  } catch (error) {
+    console.error('Token list error:', error)
+    return res.status(500).json({ success: false, error: 'Errore interno del server', message: error.message })
+  }
+}


### PR DESCRIPTION
## Summary
- init Supabase client in tokenization API
- store created token data in `tokens` table
- provide endpoint to query tokens
- document server-side Supabase environment variables

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686154958b948330b260e3e29154b80a