### PR TITLE
Backend signing for XRPL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,6 @@ REACT_APP_SUPABASE_ANON_KEY=your-supabase-anon-key-here
 # API Configuration
 REACT_APP_API_BASE_URL=https://solcraft-nexus-tokenize-v1.vercel.app/api
 
+# Backend Signing
+ISSUER_SECRET=your-issuer-secret-here
+

--- a/.env.production
+++ b/.env.production
@@ -21,6 +21,9 @@ DEFAULT_NETWORK=testnet
 API_BASE_URL=https://solcraft-nexus-platform.vercel.app/api
 FRONTEND_URL=https://solcraft-nexus-platform.vercel.app
 
+# XRPL Issuer secret (backend)
+ISSUER_SECRET=
+
 # Security
 BCRYPT_ROUNDS=12
 SESSION_DURATION=7d

--- a/api/mpt/create-advanced.js
+++ b/api/mpt/create-advanced.js
@@ -22,22 +22,30 @@ export default async function handler(req, res) {
   try {
     await client.connect()
     
-    const { 
-      issuerSeed,
+    const {
       metadata,
       maximumAmount,
       transferFee = 0,
       flags = 0,
       assetScale = 0
     } = req.body
-    
-    if (!issuerSeed || !metadata) {
-      return res.status(400).json({
+
+    const issuerSeed = process.env.ISSUER_SECRET
+
+    if (!issuerSeed) {
+      return res.status(500).json({
         success: false,
-        error: 'Issuer seed and metadata are required'
+        error: 'Issuer secret not configured'
       })
     }
-    
+
+    if (!metadata) {
+      return res.status(400).json({
+        success: false,
+        error: 'Metadata is required'
+      })
+    }
+
     const issuerWallet = Wallet.fromSeed(issuerSeed)
     
     // Prepare MPT metadata

--- a/api/xrpl/sign.js
+++ b/api/xrpl/sign.js
@@ -1,0 +1,46 @@
+import { Client, Wallet } from 'xrpl'
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end()
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ success: false, error: 'Method not allowed' })
+  }
+
+  const issuerSeed = process.env.ISSUER_SECRET
+  if (!issuerSeed) {
+    return res.status(500).json({ success: false, error: 'Issuer secret not configured' })
+  }
+
+  const { transaction } = req.body
+  if (!transaction) {
+    return res.status(400).json({ success: false, error: 'Transaction is required' })
+  }
+
+  const client = new Client(process.env.XRPL_SERVER || 'wss://s.altnet.rippletest.net:51233')
+
+  try {
+    await client.connect()
+
+    const wallet = Wallet.fromSeed(issuerSeed)
+    const tx = { Account: wallet.address, ...transaction }
+    const prepared = await client.autofill(tx)
+    const signed = wallet.sign(prepared)
+    const result = await client.submitAndWait(signed.tx_blob)
+
+    return res.status(200).json({ success: true, result: result.result })
+  } catch (error) {
+    console.error('Signing error:', error)
+    return res.status(500).json({ success: false, error: error.message })
+  } finally {
+    if (client.isConnected()) {
+      await client.disconnect()
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- remove wallet secret from frontend tokenization service
- move secret to backend and expose new API route for signing
- use ISSUER_SECRET in serverless functions
- document new environment variable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686154965e6083308500476c10b560c6