### PR TITLE
Use env vars for Supabase credentials

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for SolCraft Nexus API
+
+# Supabase service credentials
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key

--- a/api/mpt/advanced.js
+++ b/api/mpt/advanced.js
@@ -5,8 +5,8 @@ import { createClient } from '@supabase/supabase-js'
 import { Client, Wallet, xrpToDrops, dropsToXrp } from 'xrpl'
 
 // Configurazione
-const supabaseUrl = 'https://dtzlkcqddjaoubrjnzjw.supabase.co'
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImR0emxrY3FkZGphb3VicmpuempqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzUyMDQ5NjMsImV4cCI6MjA1MDc4MDk2M30.eYJhbGc1OjJIUzI1NiIsInR5cCI6IkpXVCJ9'
+const supabaseUrl = process.env.SUPABASE_URL
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
 const supabase = createClient(supabaseUrl, supabaseKey)
 

--- a/api/users/manage.js
+++ b/api/users/manage.js
@@ -7,8 +7,8 @@ import jwt from 'jsonwebtoken'
 import bcrypt from 'bcryptjs'
 
 // Configurazione
-const supabaseUrl = 'https://dtzlkcqddjaoubrjnzjw.supabase.co'
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImR0emxrY3FkZGphb3VicmpuempqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzUyMDQ5NjMsImV4cCI6MjA1MDc4MDk2M30.eYJhbGc1OjJIUzI1NiIsInR5cCI6IkpXVCJ9'
+const supabaseUrl = process.env.SUPABASE_URL
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
 const supabase = createClient(supabaseUrl, supabaseKey)
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,8 @@
 
 [build.environment]
   NODE_VERSION = "20"
+  SUPABASE_URL = "${SUPABASE_URL}"
+  SUPABASE_SERVICE_ROLE_KEY = "${SUPABASE_SERVICE_ROLE_KEY}"
 
 [[redirects]]
   from = "/api/*"

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,10 @@
   "version": 2,
   "buildCommand": "pnpm run build",
   "outputDirectory": "dist",
+  "env": {
+    "SUPABASE_URL": "@supabase-url",
+    "SUPABASE_SERVICE_ROLE_KEY": "@supabase-service-role-key"
+  },
   "rewrites": [
     {
       "source": "/api/(.*)",


### PR DESCRIPTION
## Summary
- replace hard-coded Supabase credentials with environment variables
- add example env file for the API
- pass Supabase vars through Netlify and Vercel configs

## Testing
- `pnpm run lint` *(fails: no-unused-vars, no-undef)*

------
https://chatgpt.com/codex/tasks/task_e_6861549792408330a698be160af4c128