### PR TITLE
Add token storage via Supabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,8 @@ REACT_APP_XRPL_TESTNET=wss://s.altnet.rippletest.net:51233
 # Supabase Configuration
 REACT_APP_SUPABASE_URL=your-supabase-url-here
 REACT_APP_SUPABASE_ANON_KEY=your-supabase-anon-key-here
+SUPABASE_URL=your-supabase-url-here
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key-here
 
 # API Configuration
 REACT_APP_API_BASE_URL=https://solcraft-nexus-tokenize-v1.vercel.app/api

--- a/api/tokenization/create.js
+++ b/api/tokenization/create.js
@@ -1,5 +1,6 @@
 import { getXRPLClient, initializeXRPL, walletFromSeed, createTrustLine } from '../config/xrpl.js';
 import jwt from 'jsonwebtoken';
+import { createClient } from '@supabase/supabase-js';
 
 export default async function handler(req, res) {
   res.setHeader('Access-Control-Allow-Origin', '*')
@@ -39,6 +40,10 @@ export default async function handler(req, res) {
         error: 'Token non valido'
       });
     }
+
+    const supabaseUrl = process.env.SUPABASE_URL
+    const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY
+    const supabase = createClient(supabaseUrl, supabaseKey)
 
     const {
       assetName,
@@ -171,6 +176,24 @@ export default async function handler(req, res) {
     console.log('Token created:', tokenData);
 
     if (tokenCreationResult.success) {
+      // Salva token su Supabase
+      const { error: insertError } = await supabase.from('tokens').insert({
+        id: tokenId,
+        metadata: tokenData,
+        issuer: tokenCreationResult.issuerAddress,
+        tx_hash: tokenCreationResult.txHash,
+        created_at: createdAt
+      });
+
+      if (insertError) {
+        console.error('Supabase insert error:', insertError);
+        return res.status(500).json({
+          success: false,
+          error: 'Errore salvataggio token',
+          details: insertError.message
+        });
+      }
+
       return res.status(201).json({
         success: true,
         message: 'Asset tokenizzato con successo!',

--- a/api/tokenization/list.js
+++ b/api/tokenization/list.js
@@ -1,0 +1,42 @@
+import { createClient } from '@supabase/supabase-js'
+
+export default async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+
+  if (req.method === 'OPTIONS') {
+    return res.status(200).end()
+  }
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ success: false, error: 'Method not allowed. Use GET.' })
+  }
+
+  try {
+    const supabaseUrl = process.env.SUPABASE_URL
+    const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY
+    const supabase = createClient(supabaseUrl, supabaseKey)
+
+    let query = supabase.from('tokens').select('*')
+    const { id, issuer } = req.query
+    if (id) {
+      query = query.eq('id', id)
+    }
+    if (issuer) {
+      query = query.eq('issuer', issuer)
+    }
+
+    const { data, error } = await query
+
+    if (error) {
+      console.error('Token fetch error:', error)
+      return res.status(500).json({ success: false, error: 'Errore recupero token', details: error.message })
+    }
+
+    return res.status(200).json({ success: true, tokens: data })
+  } catch (error) {
+    console.error('Token list API error:', error)
+    return res.status(500).json({ success: false, error: 'Errore interno del server', message: error.message })
+  }
+}


### PR DESCRIPTION
## Summary
- initialize Supabase client in token creation API
- store created token records in `tokens` table
- add API route to list stored tokens
- document Supabase server env vars in `.env.example`

## Testing
- `npm install`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861573781ac8330b4839418e0491a24