### PR TITLE
Update Supabase config to use environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,11 @@ REACT_APP_XRPL_TESTNET=wss://s.altnet.rippletest.net:51233
 REACT_APP_SUPABASE_URL=your-supabase-url-here
 REACT_APP_SUPABASE_ANON_KEY=your-supabase-anon-key-here
 
+# Server Supabase Configuration
+SUPABASE_URL=your-supabase-url-here
+SUPABASE_ANON_KEY=your-supabase-anon-key-here
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key-here
+
 # API Configuration
 REACT_APP_API_BASE_URL=https://solcraft-nexus-tokenize-v1.vercel.app/api
 

--- a/.env.production
+++ b/.env.production
@@ -2,9 +2,9 @@
 # Integrazione XRPL + Supabase
 
 # Supabase Configuration
-SUPABASE_URL=https://dtzlkcqddjaoubrjnzjw.supabase.co
-SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImR0emxrY3FkZGphb3VicmpuempqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzUyMDQ5NjMsImV4cCI6MjA1MDc4MDk2M30.eYJhbGc1OjJIUzI1NiIsInR5cCI6IkpXVCJ9
-SUPABASE_SERVICE_ROLE_KEY=****
+SUPABASE_URL=your-supabase-url-here
+SUPABASE_ANON_KEY=your-supabase-anon-key-here
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key-here
 
 # JWT Configuration
 JWT_SECRET=solcraft-nexus-xrpl-secure-2025

--- a/api/config/supabase.js
+++ b/api/config/supabase.js
@@ -2,9 +2,9 @@
 // Integrazione XRPL + Database
 
 const SUPABASE_CONFIG = {
-  url: 'https://dtzlkcqddjaoubrjnzjw.supabase.co',
-  anonKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImR0emxrY3FkZGphb3VicmpuempqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzUyMDQ5NjMsImV4cCI6MjA1MDc4MDk2M30.eYJhbGc1OjJIUzI1NiIsInR5cCI6IkpXVCJ9',
-  serviceRoleKey: '****' // Hidden for security
+  url: process.env.SUPABASE_URL,
+  anonKey: process.env.SUPABASE_SERVICE_ROLE_KEY,
+  serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY
 }
 
 export default SUPABASE_CONFIG

--- a/api/users/manage.js
+++ b/api/users/manage.js
@@ -7,8 +7,8 @@ import jwt from 'jsonwebtoken'
 import bcrypt from 'bcryptjs'
 
 // Configurazione
-const supabaseUrl = 'https://dtzlkcqddjaoubrjnzjw.supabase.co'
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImR0emxrY3FkZGphb3VicmpuempqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzUyMDQ5NjMsImV4cCI6MjA1MDc4MDk2M30.eYJhbGc1OjJIUzI1NiIsInR5cCI6IkpXVCJ9'
+const supabaseUrl = process.env.SUPABASE_URL
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
 const supabase = createClient(supabaseUrl, supabaseKey)
 

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,10 @@
   "version": 2,
   "buildCommand": "pnpm run build",
   "outputDirectory": "dist",
+  "env": {
+    "SUPABASE_URL": "@supabase-url",
+    "SUPABASE_SERVICE_ROLE_KEY": "@supabase-service-role-key"
+  },
   "rewrites": [
     {
       "source": "/api/(.*)",


### PR DESCRIPTION
## Summary
- reference SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY from environment
- strip real Supabase credentials from `.env.production`
- add placeholders for server variables in `.env.example`
- ensure Vercel injects Supabase variables

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68615737f5208330a693a6eaeb208169