### PR TITLE
Add SPA health check and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,28 @@ npm run dev
 4. Push to the branch (`git push origin feature/AmazingFeature`)
 5. Open a Pull Request
 
+## 🚀 Deployment on Vercel
+
+The project is configured for single page application (SPA) mode on Vercel. The
+`vercel.json` file specifies the build command and output directory and includes
+a catch‑all rewrite so that any route serves `index.html`.
+
+```
+{
+  "buildCommand": "pnpm run build",
+  "outputDirectory": "dist",
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "/api/$1" },
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}
+```
+
+After running `pnpm run build` the generated file `dist/index.html` is deployed
+and requests like `/dashboard` will resolve to that file. You can run
+`pnpm run test` to perform a basic health check that ensures `/dashboard`
+returns HTTP 200 locally.
+
 ## 📄 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node tests/healthcheck.js"
   },
   "dependencies": {
     "@crossmarkio/sdk": "^0.4.0",

--- a/tests/healthcheck.js
+++ b/tests/healthcheck.js
@@ -1,0 +1,31 @@
+import http from 'node:http'
+import fs from 'node:fs'
+import path from 'node:path'
+
+// Ensure build output exists
+if (!fs.existsSync(path.join('dist', 'index.html'))) {
+  console.error('dist/index.html not found. Did you run pnpm run build?')
+  process.exit(1)
+}
+
+// Simple HTTP server serving built index.html for any route
+const server = http.createServer((req, res) => {
+  fs.createReadStream(path.join('dist', 'index.html')).pipe(res)
+})
+
+server.listen(5080, async () => {
+  try {
+    const resp = await fetch('http://localhost:5080/dashboard')
+    if (resp.status !== 200) {
+      console.error('Expected status 200 but got', resp.status)
+      process.exitCode = 1
+    } else {
+      console.log('Health check passed')
+    }
+  } catch (err) {
+    console.error('Health check failed', err)
+    process.exitCode = 1
+  } finally {
+    server.close()
+  }
+})


### PR DESCRIPTION
## Summary
- document Vercel SPA setup and build output
- expose a simple health check script
- add a `pnpm test` script that verifies `/dashboard`

## Testing
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6861625d601c8330839ec028159de3fe