### PR TITLE
Remove admin credentials from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,7 @@ npm run dev
 ## 🔐 Default Credentials
 
 **Admin User:**
-- Email: `admin@solcraft-nexus.com`
-- Password: `admin123`
+There are no pre-defined credentials. Administrators should register through the platform and create their own login details.
 
 ## 🌟 Core Functionalities
 


### PR DESCRIPTION
## Summary
- update README to remove example admin credentials
- tell admins to register credentials through the platform

## Testing
- `pnpm run lint` *(fails: cannot find process defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68616baa19308330baccd381e8578d0a