### PR TITLE
Add security headers to vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,25 @@
       "source": "/(.*)",
       "destination": "/index.html"
     }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        }
+      ]
+    }
   ]
 }
 


### PR DESCRIPTION
## Summary
- add security headers for all routes in `vercel.json`

## Testing
- `pnpm run lint` *(fails: no-unused-vars, no-undef, etc.)*
- `pnpm run build`
- `npx vercel --version`
- `npx vercel ls` *(fails: no credentials found)*

------
https://chatgpt.com/codex/tasks/task_e_68616bae86b08330bc99c78c65dc7a2b