### PR TITLE
Implement real XRPL tokenization

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node tests/tokenization.test.cjs"
   },
   "dependencies": {
     "@crossmarkio/sdk": "^0.4.0",

--- a/tests/tokenization.test.cjs
+++ b/tests/tokenization.test.cjs
@@ -1,0 +1,48 @@
+const assert = require('assert');
+const {
+  initializeXRPL,
+  disconnectXRPL,
+  createWallet,
+  createTrustLine,
+  sendXRPPayment,
+  walletFromSeed
+} = require('../api/config/xrpl.js');
+
+(async () => {
+  try {
+    await initializeXRPL();
+    const client = require('../api/config/xrpl.js').getXRPLClient();
+
+    // Create issuer and distribution wallets
+    const issuer = await client.fundWallet();
+    const distributor = await client.fundWallet();
+
+    const issuerWallet = walletFromSeed(issuer.wallet.seed);
+    const distWallet = walletFromSeed(distributor.wallet.seed);
+
+    // Create trust line
+    const trustRes = await createTrustLine(
+      distWallet,
+      'TST',
+      issuerWallet.address,
+      '1000'
+    );
+    assert.ok(trustRes.hash);
+
+    // Issue token payment
+    const payRes = await sendXRPPayment(
+      issuerWallet,
+      distWallet.address,
+      { currency: 'TST', issuer: issuerWallet.address, value: '1000' }
+    );
+    assert.ok(payRes.hash);
+
+    console.log('Test completed successfully');
+    await disconnectXRPL();
+    process.exit(0);
+  } catch (err) {
+    console.error(err);
+    await disconnectXRPL().catch(() => {});
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add real trustline/payment logic to tokenization API
- expand XRPL config helpers for token payments
- propagate submit errors
- add basic integration test using XRPL testnet

## Testing
- `npm run lint` *(fails: no-unused-vars, process not defined, etc.)*
- `npm test` *(fails: NotConnectedError connect ENETUNREACH 35.171.235.228:51233)*

------
https://chatgpt.com/codex/tasks/task_e_6861b6daadec833094268953f8d03cfd