### PR TITLE
Add backend test suite

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -53,3 +53,6 @@ websockets==15.0.1
 Werkzeug==3.1.3
 wrapt==1.17.2
 xrpl-py==4.2.0
+
+pytest==8.2.2
+pytest-flask==1.3.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import pytest
+
+# Ensure backend package root is on the import path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.main import create_app
+from src.config import TestingConfig
+from src.models.user import db, User
+
+@pytest.fixture
+def app():
+    app = create_app()
+    app.config.from_object(TestingConfig)
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+@pytest.fixture
+def active_user(app):
+    with app.app_context():
+        user = User(
+            email='test@example.com',
+            first_name='Test',
+            last_name='User',
+            status='active'
+        )
+        user.set_password('Password1!')
+        db.session.add(user)
+        db.session.commit()
+        return user.email

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,0 +1,14 @@
+
+def test_protected_endpoint_requires_auth(client):
+    res = client.get('/api/v1/security/mfa/status')
+    assert res.status_code == 401
+
+
+def test_register_malicious_input(client):
+    res = client.post('/api/v1/users/auth/register', json={
+        'email': '<script>alert(1)</script>',
+        'password': 'Password1!',
+        'first_name': 'John',
+        'last_name': 'Doe'
+    })
+    assert res.status_code == 400

--- a/backend/tests/test_validation.py
+++ b/backend/tests/test_validation.py
@@ -1,0 +1,25 @@
+from flask import url_for
+from src.models.user import db
+
+
+def test_register_missing_email(client):
+    res = client.post('/api/v1/users/auth/register', json={
+        'password': 'Password1!',
+        'first_name': 'John',
+        'last_name': 'Doe'
+    })
+    assert res.status_code == 400
+    assert b'email' in res.data
+
+
+def test_login_missing_password(client, active_user):
+    res = client.post('/api/v1/users/auth/login', json={'email': active_user})
+    assert res.status_code == 400
+
+
+def test_mfa_verify_requires_token(client, active_user):
+    login = client.post('/api/v1/users/auth/login', json={'email': active_user, 'password': 'Password1!'})
+    token = login.get_json()['access_token']
+    headers = {'Authorization': f'Bearer {token}'}
+    res = client.post('/api/v1/security/mfa/verify', headers=headers, json={})
+    assert res.status_code == 400

--- a/backend/tests/test_xrpl_integration.py
+++ b/backend/tests/test_xrpl_integration.py
@@ -1,0 +1,27 @@
+from decimal import Decimal
+import xrpl
+from xrpl.wallet import Wallet
+from src.services.wallet_service import XRPLService
+
+
+class MockResponse:
+    def __init__(self):
+        self.result = {'hash': 'ABC123', 'Fee': '10', 'validated': True}
+
+    def is_successful(self):
+        return True
+
+
+def test_send_xrp_with_mocked_wallet(monkeypatch):
+    service = XRPLService()
+    wallet = Wallet.create()
+
+    def mock_get_account_info(address):
+        return {'available_balance': Decimal('100'), 'balance': Decimal('100'), 'reserve': Decimal('10')}
+
+    monkeypatch.setattr(service, 'get_account_info', mock_get_account_info)
+    monkeypatch.setattr(xrpl.transaction, 'submit_and_wait', lambda tx, client, w: MockResponse())
+
+    result = service.send_xrp(wallet, 'rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe', Decimal('1'))
+    assert result['success'] is True
+    assert result['hash'] == 'ABC123'


### PR DESCRIPTION
## Summary
- add pytest dependencies
- create test fixtures
- add validation tests
- add XRPL integration test with mocked wallets
- add security test for auth failures

## Testing
- `cd backend && pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861b797026c83308cef604f9f2653c3