### PR TITLE
Implement real XRPL account configuration

### DIFF
--- a/api/utils/calculateAccountFlags.js
+++ b/api/utils/calculateAccountFlags.js
@@ -1,0 +1,33 @@
+import { AccountSetAsfFlags, AccountSetTfFlags } from 'xrpl'
+
+export default function calculateAccountFlags(options = {}) {
+  let flags = 0
+  let setFlag
+  let clearFlag
+
+  const maybe = (flag, enable, tfSet, tfClear) => {
+    if (enable === true) {
+      if (tfSet) flags |= tfSet
+      if (setFlag === undefined) setFlag = flag
+    } else if (enable === false) {
+      if (tfClear) flags |= tfClear
+      if (clearFlag === undefined) clearFlag = flag
+    }
+  }
+
+  maybe(AccountSetAsfFlags.asfRequireDest, options.requireDestinationTag, AccountSetTfFlags.tfRequireDestTag, AccountSetTfFlags.tfOptionalDestTag)
+  maybe(AccountSetAsfFlags.asfRequireAuth, options.requireAuth, AccountSetTfFlags.tfRequireAuth, AccountSetTfFlags.tfOptionalAuth)
+  maybe(AccountSetAsfFlags.asfDisallowXRP, options.disallowXRP, AccountSetTfFlags.tfDisallowXRP, AccountSetTfFlags.tfAllowXRP)
+  maybe(AccountSetAsfFlags.asfDisableMaster, options.disableMaster)
+  maybe(AccountSetAsfFlags.asfAccountTxnID, options.accountTxnID)
+  maybe(AccountSetAsfFlags.asfNoFreeze, options.noFreeze)
+  maybe(AccountSetAsfFlags.asfGlobalFreeze, options.globalFreeze)
+  maybe(AccountSetAsfFlags.asfDefaultRipple, options.defaultRipple)
+  maybe(AccountSetAsfFlags.asfDepositAuth, options.depositAuth)
+
+  const result = {}
+  if (flags) result.Flags = flags
+  if (setFlag !== undefined) result.SetFlag = setFlag
+  if (clearFlag !== undefined) result.ClearFlag = clearFlag
+  return result
+}


### PR DESCRIPTION
## Summary
- add helper to compute AccountSet flags via `calculateAccountFlags`
- submit a real AccountSet tx when configuring accounts
- include domain, email hash and message key

## Testing
- `npm run lint` *(fails: cannot satisfy lint rules)*

------
https://chatgpt.com/codex/tasks/task_e_6861bbbc9a2c8330aff6c6c94bb2b516