### PR TITLE
Add security headers middleware

### DIFF
--- a/api/account/configure.js
+++ b/api/account/configure.js
@@ -1,10 +1,11 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { getXRPLClient, initializeXRPL, getAccountInfo } from '../config/xrpl.js';
 import { AccountSet, convertStringToHex } from 'xrpl';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
+  applySecurityHeaders(res);
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/account/create.js
+++ b/api/account/create.js
@@ -1,10 +1,11 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { getXRPLClient, initializeXRPL, walletFromSeed } from '../config/xrpl.js';
 import { Wallet } from 'xrpl';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
+  applySecurityHeaders(res);
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/account/info.js
+++ b/api/account/info.js
@@ -1,8 +1,9 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { Client } from 'xrpl'
 
 export default async function handler(req, res) {
+  applySecurityHeaders(res);
   // Enable CORS
-  res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
   

--- a/api/account/trustlines.js
+++ b/api/account/trustlines.js
@@ -1,9 +1,10 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { getXRPLClient, initializeXRPL, getAccountInfo } from '../config/xrpl.js';
 import { TrustSet, convertStringToHex } from 'xrpl';
 import jwt from 'jsonwebtoken';
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
+  applySecurityHeaders(res);
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/analytics/portfolio-advanced.js
+++ b/api/analytics/portfolio-advanced.js
@@ -1,8 +1,9 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { Client } from 'xrpl'
 
 export default async function handler(req, res) {
+  applySecurityHeaders(res);
   // Enable CORS
-  res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
   

--- a/api/analytics/portfolio.js
+++ b/api/analytics/portfolio.js
@@ -1,8 +1,9 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { getXRPLClient, initializeXRPL } from '../config/xrpl.js';
 import jwt from 'jsonwebtoken';
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
+  applySecurityHeaders(res);
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/assets/list.js
+++ b/api/assets/list.js
@@ -1,6 +1,7 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 export default async function handler(req, res) {
+  applySecurityHeaders(res);
   // CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/assets/manage.js
+++ b/api/assets/manage.js
@@ -1,9 +1,10 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { getXRPLClient, initializeXRPL } from '../config/xrpl.js';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
+  applySecurityHeaders(res);
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -1,10 +1,11 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcryptjs');
 import { supabase, getUserByEmail, handleSupabaseError } from '../config/supabaseClient.js';
 
 export default async function handler(req, res) {
+  applySecurityHeaders(res);
   // Gestione CORS
-  res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
 

--- a/api/auth/oauth/apple.js
+++ b/api/auth/oauth/apple.js
@@ -1,9 +1,10 @@
+import { applySecurityHeaders } from '../../../utils/securityHeaders.js';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 
 export default async function handler(req, res) {
+  applySecurityHeaders(res);
   // CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/auth/oauth/github.js
+++ b/api/auth/oauth/github.js
@@ -1,8 +1,9 @@
+import { applySecurityHeaders } from '../../../utils/securityHeaders.js';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
+  applySecurityHeaders(res);
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/auth/oauth/google.js
+++ b/api/auth/oauth/google.js
@@ -1,11 +1,12 @@
+import { applySecurityHeaders } from '../../../utils/securityHeaders.js';
 // Netlify Function - Google OAuth
 exports.handler = async (event, context) => {
   const headers = {
-    'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     'Content-Type': 'application/json'
   }
+  applySecurityHeaders({ setHeader: (k, v) => (headers[k] = v) })
 
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 200, headers, body: '' }

--- a/api/auth/register.js
+++ b/api/auth/register.js
@@ -1,10 +1,11 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcryptjs');
 import { supabase, getUserByEmail, insertUser, handleSupabaseError } from '../config/supabaseClient.js';
 
 export default async function handler(req, res) {
+  applySecurityHeaders(res);
   // Gestione CORS
-  res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
 

--- a/api/auth/web3auth.js
+++ b/api/auth/web3auth.js
@@ -1,10 +1,11 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 const jwt = require('jsonwebtoken');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'solcraft-nexus-secret-key-2025';
 
 export default async function handler(req, res) {
+  applySecurityHeaders(res);
   // CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
   res.setHeader('Content-Type', 'application/json');

--- a/api/compliance/audit-trail.js
+++ b/api/compliance/audit-trail.js
@@ -1,8 +1,9 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { Client } from 'xrpl'
 
 export default async function handler(req, res) {
+  applySecurityHeaders(res);
   // Enable CORS
-  res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
   

--- a/api/crypto/receive.js
+++ b/api/crypto/receive.js
@@ -1,6 +1,7 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 export default async function handler(req, res) {
+  applySecurityHeaders(res);
   // CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/crypto/send.js
+++ b/api/crypto/send.js
@@ -1,6 +1,7 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 export default async function handler(req, res) {
+  applySecurityHeaders(res);
   // CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/dashboard/overview.js
+++ b/api/dashboard/overview.js
@@ -1,9 +1,10 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { getXRPLClient, initializeXRPL, getAccountInfo } from '../config/xrpl.js';
 import jwt from 'jsonwebtoken';
 import { dropsToXrp } from 'xrpl';
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
+  applySecurityHeaders(res);
   res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/dex/arbitrage.js
+++ b/api/dex/arbitrage.js
@@ -1,8 +1,9 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { getXRPLClient, initializeXRPL } from '../config/xrpl.js';
 import jwt from 'jsonwebtoken';
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
+  applySecurityHeaders(res);
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/dex/integration.js
+++ b/api/dex/integration.js
@@ -1,8 +1,9 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { getXRPLClient, initializeXRPL } from '../config/xrpl.js';
 import jwt from 'jsonwebtoken';
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
+  applySecurityHeaders(res);
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/dex/liquidity.js
+++ b/api/dex/liquidity.js
@@ -1,8 +1,9 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { getXRPLClient, initializeXRPL } from '../config/xrpl.js';
 import jwt from 'jsonwebtoken';
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
+  applySecurityHeaders(res);
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/dex/orderbook.js
+++ b/api/dex/orderbook.js
@@ -1,8 +1,9 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { Client, Wallet } from 'xrpl'
 
 export default async function handler(req, res) {
+  applySecurityHeaders(res);
   // Enable CORS
-  res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
   

--- a/api/dex/pathfinding.js
+++ b/api/dex/pathfinding.js
@@ -1,8 +1,9 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { Client } from 'xrpl'
 
 export default async function handler(req, res) {
+  applySecurityHeaders(res);
   // Enable CORS
-  res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
   

--- a/api/marketplace/list.js
+++ b/api/marketplace/list.js
@@ -1,6 +1,7 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 export default async function handler(req, res) {
+  applySecurityHeaders(res);
   // CORS headers
-  res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/mpt/advanced.js
+++ b/api/mpt/advanced.js
@@ -1,3 +1,4 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 // SolCraft Nexus - Multi-Purpose Tokens API
 // Implementazione completa basata su studio XRPL approfondito
 
@@ -18,8 +19,8 @@ const XRPL_NETWORKS = {
 }
 
 export default async function handler(req, res) {
+  applySecurityHeaders(res);
   // CORS Headers
-  res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
   

--- a/api/mpt/create-advanced.js
+++ b/api/mpt/create-advanced.js
@@ -1,8 +1,9 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { Client, Wallet } from 'xrpl'
 
 export default async function handler(req, res) {
+  applySecurityHeaders(res);
   // Enable CORS
-  res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
   

--- a/api/mpt/create.js
+++ b/api/mpt/create.js
@@ -1,10 +1,11 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { getXRPLClient, initializeXRPL, getAccountInfo } from '../config/xrpl.js';
 import { supabase, insertAsset, insertToken, insertTransaction, handleSupabaseError } from '../config/supabaseClient.js';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
+  applySecurityHeaders(res);
   res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/mpt/manage.js
+++ b/api/mpt/manage.js
@@ -1,9 +1,10 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { getXRPLClient, initializeXRPL, getAccountInfo } from '../config/xrpl.js';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
+  applySecurityHeaders(res);
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/mpt/transfer.js
+++ b/api/mpt/transfer.js
@@ -1,8 +1,9 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { Client, Wallet } from 'xrpl'
 
 export default async function handler(req, res) {
+  applySecurityHeaders(res);
   // Enable CORS
-  res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
   

--- a/api/payments/receive.js
+++ b/api/payments/receive.js
@@ -1,9 +1,10 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { getXRPLClient, initializeXRPL, getAccountInfo } from '../config/xrpl.js';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
+  applySecurityHeaders(res);
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/payments/send.js
+++ b/api/payments/send.js
@@ -1,10 +1,11 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { getXRPLClient, initializeXRPL, getAccountInfo } from '../config/xrpl.js';
 import { Payment, convertStringToHex, xrpToDrops, dropsToXrp } from 'xrpl';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
+  applySecurityHeaders(res);
   res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/reports/generate.js
+++ b/api/reports/generate.js
@@ -1,8 +1,9 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { getXRPLClient, initializeXRPL } from '../config/xrpl.js';
 import jwt from 'jsonwebtoken';
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
+  applySecurityHeaders(res);
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/tokenization/create.js
+++ b/api/tokenization/create.js
@@ -1,9 +1,10 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { getXRPLClient, initializeXRPL, walletFromSeed, createTrustLine } from '../config/xrpl.js';
 import { supabase, insertAsset, insertToken, insertTransaction, handleSupabaseError } from '../config/supabaseClient.js';
 import jwt from 'jsonwebtoken';
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
+  applySecurityHeaders(res);
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/trading/orders.js
+++ b/api/trading/orders.js
@@ -1,8 +1,9 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { getXRPLClient, initializeXRPL } from '../config/xrpl.js';
 import jwt from 'jsonwebtoken';
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
+  applySecurityHeaders(res);
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/transactions/history.js
+++ b/api/transactions/history.js
@@ -1,9 +1,10 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 import { getXRPLClient, initializeXRPL } from '../config/xrpl.js';
 import jwt from 'jsonwebtoken';
 import { dropsToXrp } from 'xrpl';
 
 export default async function handler(req, res) {
-  res.setHeader('Access-Control-Allow-Origin', '*')
+  applySecurityHeaders(res);
   res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
 

--- a/api/users/manage.js
+++ b/api/users/manage.js
@@ -1,3 +1,4 @@
+import { applySecurityHeaders } from '../../utils/securityHeaders.js';
 // SolCraft Nexus - User Management API
 // Integrazione XRPL + Supabase basata su studio approfondito
 
@@ -20,8 +21,8 @@ const XRPL_NETWORKS = {
 }
 
 export default async function handler(req, res) {
+  applySecurityHeaders(res);
   // CORS Headers
-  res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
   

--- a/utils/securityHeaders.js
+++ b/utils/securityHeaders.js
@@ -1,0 +1,6 @@
+export function applySecurityHeaders(res) {
+  const allowedOrigin = process.env.FRONTEND_URL || 'https://solcraft-nexus-platform.vercel.app';
+  res.setHeader('Content-Security-Policy', "default-src 'self'");
+  res.setHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload');
+  res.setHeader('Access-Control-Allow-Origin', allowedOrigin);
+}


### PR DESCRIPTION
## Summary
- add middleware for common security headers
- apply the middleware across all API routes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861bbc472e4833095720ea5de8c02b1