### PR TITLE
Add Jest tests and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,12 @@
+name: Node.js CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm test

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+export default {
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.js']
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "dependencies": {
     "@crossmarkio/sdk": "^0.4.0",
@@ -90,7 +91,8 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
     "tw-animate-css": "^1.2.9",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "jest": "^30.0.0"
   },
   "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af"
 }

--- a/tests/integration/tokenCreation.test.js
+++ b/tests/integration/tokenCreation.test.js
@@ -1,0 +1,28 @@
+import { tokenizationService } from '../../frontend/src/services/xrplTokenizationService.js';
+import { Client, Wallet } from 'xrpl';
+
+jest.setTimeout(60000);
+
+describe('XRPL token creation flow', () => {
+  test('creates a token on XRPL testnet', async () => {
+    const client = new Client('wss://s.altnet.rippletest.net:51233');
+    await client.connect();
+    const { wallet } = await client.fundWallet();
+
+    process.env.VITE_ISSUER_SECRET = wallet.seed;
+    process.env.VITE_ISSUER_ADDRESS = wallet.address;
+    process.env.VITE_XRPL_SERVER = 'wss://s.altnet.rippletest.net:51233';
+
+    const token = await tokenizationService.createRealEstateToken({
+      name: 'TestAsset',
+      symbol: 'TST',
+      location: 'Test',
+      faceValue: 100,
+      totalSupply: 1
+    });
+
+    expect(token).toHaveProperty('mptIssuanceId');
+    await tokenizationService.disconnect();
+    await client.disconnect();
+  });
+});

--- a/tests/unit/xrplTokenizationService.test.js
+++ b/tests/unit/xrplTokenizationService.test.js
@@ -1,0 +1,24 @@
+import { tokenizationService } from '../../frontend/src/services/xrplTokenizationService.js';
+
+describe('validateAssetData', () => {
+  test('throws on missing required fields', () => {
+    expect(() => tokenizationService.validateAssetData({})).toThrow('Campo obbligatorio mancante');
+  });
+
+  test('throws on invalid supply', () => {
+    const data = { name: 'House', symbol: 'HSE', location: 'Rome', faceValue: 100, totalSupply: 0 };
+    expect(() => tokenizationService.validateAssetData(data)).toThrow('Total supply');
+  });
+
+  test('accepts valid data', () => {
+    const data = { name: 'House', symbol: 'HSE', location: 'Rome', faceValue: 100, totalSupply: 10 };
+    expect(() => tokenizationService.validateAssetData(data)).not.toThrow();
+  });
+});
+
+describe('extractMPTIssuanceId', () => {
+  test('throws when id missing', () => {
+    const res = { result: { meta: { CreatedNodes: [] } } };
+    expect(() => tokenizationService.extractMPTIssuanceId(res)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for tokenization validation and extraction logic
- add integration test connecting to XRPL testnet
- set up Jest config and npm test script
- configure GitHub Actions to run the tests

## Testing
- `npm test` *(fails: Cannot find module '.../jest')*

------
https://chatgpt.com/codex/tasks/task_e_6861bbd01c748330bd51b9fe56dc1cf2