### PR TITLE
fix: adjust Vite paths

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,20 +6,20 @@ import path from 'path'
 // https://vite.dev/config/
 export default defineConfig({
   // Specifica la directory root del frontend
-  root: './frontend',
+  root: './',
   
   plugins: [react(), tailwindcss()],
   
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./frontend/src"),
+      "@": path.resolve(__dirname, "./src"),
     },
   },
   
   // Configurazione build
   build: {
     // Output nella directory dist della root del progetto
-    outDir: '../dist',
+    outDir: './dist',
     // Pulisce la directory di output prima del build
     emptyOutDir: true,
     // Configurazione per ottimizzazione


### PR DESCRIPTION
## Summary
- update vite config path settings

## Testing
- `npm run lint` *(fails: __dirname is not defined, 789 errors)*
- `npm run netlify:build` *(fails: Could not resolve entry module "index.html")*

------
https://chatgpt.com/codex/tasks/task_e_686306ebcb008330b2498141710c7773