### PR TITLE
Fix Netlify build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ cd frontend
 npm install
 npm run dev
 ```
+For a production build (used by Netlify), run:
+```bash
+npm install && npm run build
+```
 
 ## 🔌 API Endpoints
 

--- a/docs/documentazione_finale.md
+++ b/docs/documentazione_finale.md
@@ -149,6 +149,10 @@ cd solcraft-nexus-frontend
 npm install
 npm run dev
 ```
+Per creare una build di produzione (come avviene su Netlify):
+```bash
+npm install && npm run build
+```
 
 ## 🔐 Credenziali Default
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,6 @@
 [build]
-  command = "npm install --no-frozen-lockfile && npm run build"
+  # Install dependencies and build the frontend using npm
+  command = "npm install && npm run build"
   functions = "netlify/functions"
   publish = "dist"
 


### PR DESCRIPTION
## Summary
- fix the Netlify build command to use npm
- document the production build workflow in README and docs

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68631bae51d48330938d043eff0e78ed