### PR TITLE
Remove hardcoded redis tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,9 +22,9 @@ REACT_APP_SUPABASE_ANON_KEY=your-supabase-anon-key-here
 REACT_APP_API_BASE_URL=https://solcraft-nexus-tokenize-v1.vercel.app/api
 
 # Redis Configuration (Upstash)
-REDIS_URL=rediss://default:AUHXAAIjcDEwYTMzMjJiZjMyZjE0YmUzYTg5NzZkOTczMzRmY2JlN3AxMA@trusted-grackle-16855.upstash.io:6379
-UPSTASH_REDIS_REST_URL=https://trusted-grackle-16855.upstash.io
-UPSTASH_REDIS_REST_TOKEN=AkHXAAIgcDHtRT0JFBE_i6iQG_9O9zIKlH3arFQzSZbEaotOjnQlcw
+REDIS_URL=your-redis-url-here
+UPSTASH_REDIS_REST_URL=https://your-upstash-instance.upstash.io
+UPSTASH_REDIS_REST_TOKEN=your-upstash-redis-rest-token
 
 # Cache Configuration
 CACHE_TTL_DEFAULT=3600

--- a/api/health/redis.js
+++ b/api/health/redis.js
@@ -16,10 +16,14 @@ export default async function handler(req, res) {
   }
 
   try {
+    if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) {
+      throw new Error('Upstash Redis environment variables not configured');
+    }
+
     // Configurazione Redis con credenziali Upstash
     const redis = new Redis({
-      url: process.env.UPSTASH_REDIS_REST_URL || 'https://trusted-grackle-16855.upstash.io',
-      token: process.env.UPSTASH_REDIS_REST_TOKEN || 'AkHXAAIgcDHtRT0JFBE_i6iQG_9O9zIKlH3arFQzSZbEaotOjnQlcw'
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN
     });
 
     const startTime = Date.now();
@@ -64,8 +68,8 @@ export default async function handler(req, res) {
         }
       },
       configuration: {
-        url: process.env.UPSTASH_REDIS_REST_URL ? 'configured' : 'using_default',
-        token: process.env.UPSTASH_REDIS_REST_TOKEN ? 'configured' : 'using_default'
+        url: process.env.UPSTASH_REDIS_REST_URL ? 'configured' : 'missing',
+        token: process.env.UPSTASH_REDIS_REST_TOKEN ? 'configured' : 'missing'
       },
       timestamp: new Date().toISOString(),
       environment: process.env.NODE_ENV || 'development'

--- a/api/test/redis-test.js
+++ b/api/test/redis-test.js
@@ -7,8 +7,8 @@ async function testRedisConnection() {
     
     // Configurazione Redis con credenziali Upstash
     const redis = new Redis({
-      url: 'https://trusted-grackle-16855.upstash.io',
-      token: 'AkHXAAIgcDHtRT0JFBE_i6iQG_9O9zIKlH3arFQzSZbEaotOjnQlcw'
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN
     });
     
     // Test ping
@@ -67,9 +67,9 @@ async function testRedisConfig() {
   console.log('🔧 Testing Redis configuration...');
   
   const config = {
-    url: 'https://trusted-grackle-16855.upstash.io',
-    token: 'AkHXAAIgcDHtRT0JFBE_i6iQG_9O9zIKlH3arFQzSZbEaotOjnQlcw',
-    redis_url: 'rediss://default:AUHXAAIjcDEwYTMzMjJiZjMyZjE0YmUzYTg5NzZkOTczMzRmY2JlN3AxMA@trusted-grackle-16855.upstash.io:6379'
+    url: process.env.UPSTASH_REDIS_REST_URL,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN,
+    redis_url: process.env.REDIS_URL
   };
   
   console.log('📋 Redis Configuration:');

--- a/netlify/functions/health/redis.js
+++ b/netlify/functions/health/redis.js
@@ -19,10 +19,15 @@ exports.handler = async (event, context) => {
   }
 
   try {
+    // Ensure environment variables are provided
+    if (!process.env.UPSTASH_REDIS_REST_URL || !process.env.UPSTASH_REDIS_REST_TOKEN) {
+      throw new Error('Upstash Redis environment variables not configured');
+    }
+
     // Configurazione Redis Upstash
     const redis = new Redis({
-      url: process.env.UPSTASH_REDIS_REST_URL || 'https://trusted-grackle-16855.upstash.io',
-      token: process.env.UPSTASH_REDIS_REST_TOKEN || 'AkHXAAIgcDHtRT0JFBE_i6iQG_9O9zIKlH3arFQzSZbEaotOjnQlcw'
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN
     });
 
     // Test connessione Redis

--- a/netlify/functions/test/redis-test.js
+++ b/netlify/functions/test/redis-test.js
@@ -54,8 +54,8 @@ async function testRedisConnection() {
     
     // Configurazione Redis con credenziali Upstash
     const redis = new Redis({
-      url: 'https://trusted-grackle-16855.upstash.io',
-      token: 'AkHXAAIgcDHtRT0JFBE_i6iQG_9O9zIKlH3arFQzSZbEaotOjnQlcw'
+      url: process.env.UPSTASH_REDIS_REST_URL,
+      token: process.env.UPSTASH_REDIS_REST_TOKEN
     });
     
     // Test ping
@@ -114,9 +114,9 @@ async function testRedisConfig() {
   console.log('🔧 Testing Redis configuration...');
   
   const config = {
-    url: 'https://trusted-grackle-16855.upstash.io',
-    token: 'AkHXAAIgcDHtRT0JFBE_i6iQG_9O9zIKlH3arFQzSZbEaotOjnQlcw',
-    redis_url: 'rediss://default:AUHXAAIjcDEwYTMzMjJiZjMyZjE0YmUzYTg5NzZkOTczMzRmY2JlN3AxMA@trusted-grackle-16855.upstash.io:6379'
+    url: process.env.UPSTASH_REDIS_REST_URL,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN,
+    redis_url: process.env.REDIS_URL
   };
   
   console.log('📋 Redis Configuration:');


### PR DESCRIPTION
## Summary
- load Upstash credentials from env variables only
- update health endpoints to fail when missing env vars
- use env vars in redis test scripts
- replace real tokens with placeholders in `.env.example`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68631ba9df1083309cc1480c4b6dad7e