### PR TITLE
Add Netlify build debug setting

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,7 @@
   NODE_VERSION = "20"
   NPM_VERSION = "10"
   PNPM_VERSION = "9"
+  NETLIFY_BUILD_DEBUG = "true"
 
 [dev]
   framework = "vite"


### PR DESCRIPTION
## Summary
- enable verbose build logs on Netlify by setting `NETLIFY_BUILD_DEBUG = "true"`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68631bb017948330a239d69f6f9eca9d