### PR TITLE
Move vite dependencies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -65,13 +65,14 @@
         "vaul": "^1.1.2",
         "xrpl": "^2.14.3",
         "xumm-oauth2-pkce": "^2.8.7",
-        "zod": "^3.24.4"
+        "zod": "^3.24.4",
+        "vite": "^6.3.5",
+        "@vitejs/plugin-react": "^4.4.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
-        "@vitejs/plugin-react": "^4.4.1",
         "eslint": "^9.25.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,19 +67,19 @@
     "vaul": "^1.1.2",
     "xrpl": "^2.14.3",
     "xumm-oauth2-pkce": "^2.8.7",
-    "zod": "^3.24.4"
+    "zod": "^3.24.4",
+    "vite": "^6.3.5",
+    "@vitejs/plugin-react": "^4.4.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
-    "@vitejs/plugin-react": "^4.4.1",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
-    "tw-animate-css": "^1.2.9",
-    "vite": "^6.3.5"
+    "tw-animate-css": "^1.2.9"
   },
   "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,11 @@
       "dependencies": {
         "@upstash/redis": "^1.35.0",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "vite": "^6.3.5",
+        "@vitejs/plugin-react": "^4.4.1"
       },
-      "devDependencies": {
-        "@vitejs/plugin-react": "^4.4.1",
-        "vite": "^6.3.5"
-      }
+      "devDependencies": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -86,20 +86,20 @@
     "xrpl": "^4.3.0",
     "xumm": "^1.8.0",
     "xumm-sdk": "^1.11.2",
-    "zod": "^3.24.4"
+    "zod": "^3.24.4",
+    "vite": "^6.3.5",
+    "@vitejs/plugin-react": "^4.4.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
-    "@vitejs/plugin-react": "^4.4.1",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
     "netlify-cli": "^17.38.1",
-    "tw-animate-css": "^1.2.9",
-    "vite": "^6.3.5"
+    "tw-animate-css": "^1.2.9"
   },
   "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af"
 }


### PR DESCRIPTION
## Summary
- move `vite` and `@vitejs/plugin-react` from devDependencies to dependencies
- update both lockfiles

## Testing
- `npm install --package-lock-only --silent`

------
https://chatgpt.com/codex/tasks/task_e_68631bac07b08330bba6603924f77479